### PR TITLE
[BUGFIX][HDVS-559] Create patch for missing company name when saving …

### DIFF
--- a/data/patches/magento/2.4.8/0636_guest_checkout_company_validation.patch
+++ b/data/patches/magento/2.4.8/0636_guest_checkout_company_validation.patch
@@ -1,0 +1,11 @@
+diff --git a/vendor/magento/module-quote/Model/CustomerManagement.php b/vendor/magento/module-quote/Model/CustomerManagement.php
+--- a/vendor/magento/module-quote/Model/CustomerManagement.php
++++ b/vendor/magento/module-quote/Model/CustomerManagement.php
+@@ -169,6 +169,7 @@ class CustomerManagement
+             $customerAddress->setPostcode($billingAddress->getPostcode());
+             $customerAddress->setTelephone($billingAddress->getTelephone());
+             $customerAddress->setCountryId($billingAddress->getCountryId());
++            $customerAddress->setCompany($billingAddress->getCompany());
+             $customerAddress->setCustomAttributes($billingAddress->getCustomAttributes());
+             $addresses[] = $customerAddress;
+         }


### PR DESCRIPTION
…customer data

https://github.com/magento/magento2/issues/40011

The filled in company value was never validated and saved when checking out your shopping cart
